### PR TITLE
Add support for multiple SSH config files with glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ containers.
 ## Customization
 
 - consult-tramp-method: (default: `scpx`)
-- consult-tramp-ssh-config:  (default: `~/.ssh/config`)
+- consult-tramp-ssh-config:  (default: `'("~/.ssh/config")`) - List of paths or glob patterns (e.g., `'("~/.ssh/config" "~/.ssh/conf.d/*")`)
 - consult-tramp-enable-shosts: (default: `t`)
 - consult-tramp-known-hosts: (default: `~/.ssh/known_hosts`)
 - consult-tramp-enable-docker: (default: `t`)


### PR DESCRIPTION
## Summary

This PR extends `consult-tramp-ssh-config` to accept a list of paths or glob patterns,
enabling users to organize SSH configurations across multiple files.

いつも便利に使わせてもらっています。ありがとうございます。

## Changes

- Change `consult-tramp-ssh-config` from a single string to a list of strings
- Add `consult-tramp--expand-ssh-configs` function to expand paths and glob patterns
- Maintain backward compatibility with string values
- Default value includes `~/.ssh/config` and `~/.ssh/config.d/*`

## Use Case

Many users split their SSH configurations into multiple files for better organization:

~/.ssh/config           # Main config
~/.ssh/config.d/work    # Work-related hosts
~/.ssh/config.d/personal # Personal hosts

With this change, users can configure:

```elisp
(setq consult-tramp-ssh-config '("~/.ssh/config" "~/.ssh/config.d/*"))
```

##  Backward Compatibility

Existing configurations using a single string will continue to work:

```elisp
;; Still works
(setq consult-tramp-ssh-config "~/.ssh/config")
```
